### PR TITLE
bluetooth: fixed #ifdef'ed PM callbacks ("BTLowPower" wakelock)

### DIFF
--- a/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci.c
+++ b/drivers/bluetooth/broadcom/line_discipline_driver/brcm_hci.c
@@ -47,7 +47,7 @@
 #include <linux/skbuff.h>
 #include <linux/serial_core.h>
 
-#ifdef CONFIG_MACH_SONY_SHINANO
+#ifdef CONFIG_BT_BCM4339
 #include <mach/bcm4339_bt_lpm.h>
 #endif
 
@@ -347,7 +347,7 @@ static int brcm_enqueue(struct hci_uart *hu, struct sk_buff *skb)
     struct brcm_struct *brcm = hu->priv;
     unsigned long lock_flags;
     BRCM_HCI_DBG(V4L2_DBG_TX, "hu %p skb %p", hu, skb);
-#ifdef CONFIG_MACH_SONY_SHINANO
+#ifdef CONFIG_BT_BCM4339
     bcm_bt_lpm_exit_lpm();
 #endif
     spin_lock_irqsave(&hu->lock, lock_flags);
@@ -640,7 +640,7 @@ static int brcm_recv(struct hci_uart *hu, void *data, int count)
     }
     BRCM_HCI_DBG(V4L2_DBG_RX, "%s count %d",__func__,count);
 
-#ifdef CONFIG_MACH_SONY_SHINANO
+#ifdef CONFIG_BT_BCM4339
     bcm_bt_lpm_reset_timer();
 #endif
     return count;


### PR DESCRIPTION
The CONFIG_MACH_SONY_SHINANO is nowhere defined in this kernel tree, so replace '#ifdefs' by CONFIG_BT_BCM4339.

This fixes power management callbacks of bluetooth driver that are broken since 0f70237a20ea023531842aa79170a9f9d4e62081, resulting in a persistent "BTLowPower" wakelock.
